### PR TITLE
Per-listener error isolation + optional Rails post-commit dispatch (3.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,20 @@ bus = Koine::EventManager::TransactionalEventManager.new(
 Requires ActiveRecord >= 7.2; the core library remains dependency-free, so only load
 this file from within a Rails/ActiveRecord process.
 
+Subscribers (and block listeners) are deferred by default. A reaction that must run
+**inside** the transaction — e.g. to write a related record atomically, or to raise
+and roll the whole operation back — can opt out with `after_commit: false`:
+
+```ruby
+bus.subscribe(AuditWriter.new, to: ProposalCreated)                      # post-commit, isolated
+bus.subscribe(InventoryReserver.new, to: ProposalCreated, after_commit: false) # in-transaction
+bus.listen_to(ProposalCreated, after_commit: false) { |e| ... }          # in-transaction block
+```
+
+Synchronous (`after_commit: false`) listeners run inline and their errors **propagate**
+(bypassing `on_error`), so a failed integrity reaction aborts the surrounding
+transaction. Deferred listeners stay isolated by `on_error`.
+
 ## API Reference
 
 ### EventManager

--- a/README.md
+++ b/README.md
@@ -242,12 +242,55 @@ class SessionsController < ApplicationController
 end
 ```
 
+### Error Isolation
+
+By default, an exception raised by a listener or subscriber propagates and aborts
+the dispatch. Pass an `on_error` callback to isolate failures so the remaining
+listeners still run:
+
+```ruby
+event_manager = Koine::EventManager::EventManager.new(
+  on_error: ->(error, event:, listener:) { Bugsnag.notify(error) }
+)
+```
+
+The callback is invoked as `on_error.call(error, event:, listener:)`, so it **must
+accept the `event:` and `listener:` keyword arguments** (the failing event and the
+listener/subscriber that raised). Use them to attribute the failure, or ignore them
+with a splat:
+
+```ruby
+on_error: ->(error, **) { Bugsnag.notify(error) }
+```
+
+Without `on_error` the behavior is unchanged (errors re-raise).
+
+### Post-commit Dispatch (Rails)
+
+`require "koine/event_manager/rails"` adds `TransactionalEventManager`, a drop-in
+subclass that defers dispatch until the current database transaction commits (or
+runs immediately when none is open), via `ActiveRecord.after_all_transactions_commit`.
+This keeps listeners from reacting to changes that a rollback would undo.
+
+```ruby
+require "koine/event_manager/rails"
+
+bus = Koine::EventManager::TransactionalEventManager.new(
+  on_error: ->(error, **) { Bugsnag.notify(error) }
+)
+```
+
+Requires ActiveRecord >= 7.2; the core library remains dependency-free, so only load
+this file from within a Rails/ActiveRecord process.
+
 ## API Reference
 
 ### EventManager
 
+- `EventManager.new(on_error: nil)` - Optionally isolate listener errors (see Error Isolation)
 - `listen_to(event_class, &block)` - Register a block to handle events
 - `trigger(event)` - Dispatch an event to all listeners and subscribers
+- `publish(event)` - Alias for `trigger` (pub/sub vocabulary)
 - `subscribe(subscriber, to: event_type)` - Add a subscriber for an event type
 - `unsubscribe(subscriber, from: event_type)` - Remove a subscriber
 - `attach_listener(listener)` - Attach an EventListener instance

--- a/lib/koine/event_manager/event_listener.rb
+++ b/lib/koine/event_manager/event_listener.rb
@@ -3,9 +3,10 @@
 module Koine
   module EventManager
     class EventListener
-      def initialize
+      def initialize(on_error: nil)
         @listeners = {}
         @subscribers = {}
+        @on_error = on_error
       end
 
       def listen_to(event_type, &block)
@@ -30,13 +31,13 @@ module Koine
 
       def trigger(event_object)
         listeners_for(event_object.class).each do |block|
-          block.call(event_object)
+          dispatch(event_object, block) { block.call(event_object) }
         end
 
         subscribers.each do |subscriber, events|
           events.each do |event|
             if event_object.class.ancestors.map(&:to_s).include?(event.to_s)
-              subscriber.publish(event_object)
+              dispatch(event_object, subscriber) { subscriber.publish(event_object) }
             end
           end
         end
@@ -49,6 +50,14 @@ module Koine
       end
 
       private
+
+      def dispatch(event, listener)
+        yield
+      rescue StandardError => e
+        raise if @on_error.nil?
+
+        @on_error.call(e, event: event, listener: listener)
+      end
 
       def add_listener(event_type, &block)
         listeners[event_type.to_s] ||= []

--- a/lib/koine/event_manager/event_manager.rb
+++ b/lib/koine/event_manager/event_manager.rb
@@ -3,8 +3,13 @@
 module Koine
   module EventManager
     class EventManager
-      def initialize
-        @internal_listener = EventListener.new
+      def initialize(on_error: nil)
+        @on_error = on_error
+        @internal_listener = EventListener.new(on_error: on_error)
+      end
+
+      def publish(event)
+        trigger(event)
       end
 
       def listen_to(event, &block)
@@ -31,12 +36,22 @@ module Koine
         @internal_listener.trigger(event)
 
         listeners.each do |listener|
-          listener.trigger(event)
+          dispatch(event, listener) { listener.trigger(event) }
         end
       end
 
       def listeners
         @listeners ||= []
+      end
+
+      private
+
+      def dispatch(event, listener)
+        yield
+      rescue StandardError => e
+        raise if @on_error.nil?
+
+        @on_error.call(e, event: event, listener: listener)
       end
     end
   end

--- a/lib/koine/event_manager/rails.rb
+++ b/lib/koine/event_manager/rails.rb
@@ -11,6 +11,13 @@ module Koine
       alias dispatch_now trigger
 
       def trigger(event)
+        available = defined?(::ActiveRecord) &&
+          ::ActiveRecord.respond_to?(:after_all_transactions_commit)
+        unless available
+          raise LoadError, 'TransactionalEventManager requires ActiveRecord >= 7.2 ' \
+                           '(after_all_transactions_commit). Load Rails before using it.'
+        end
+
         ::ActiveRecord.after_all_transactions_commit do
           dispatch_now(event)
         end

--- a/lib/koine/event_manager/rails.rb
+++ b/lib/koine/event_manager/rails.rb
@@ -4,26 +4,62 @@ require 'koine/event_manager'
 
 module Koine
   module EventManager
-    # Defers dispatch until the current DB transaction commits (or runs
-    # immediately when none is open). Loads ActiveRecord lazily so the core
-    # stays dependency-free.
+    # Dispatches listeners after the current DB transaction commits (or runs
+    # immediately when none is open), so they never react to changes a rollback
+    # would undo. Requires ActiveRecord >= 7.2.
+    #
+    # Individual subscribers/listeners may opt into synchronous, in-transaction
+    # dispatch with `after_commit: false`. Those run inline and their errors
+    # propagate (bypassing `on_error` isolation), so an integrity reaction can
+    # abort the surrounding transaction. Post-commit listeners stay isolated.
     class TransactionalEventManager < EventManager
-      alias dispatch_now trigger
+      alias deferred_dispatch trigger
+
+      def initialize(on_error: nil)
+        super
+        # In-transaction listeners: no on_error isolation, so a failure propagates
+        # and can roll the surrounding transaction back.
+        @synchronous = EventListener.new
+      end
+
+      def subscribe(subscriber, to:, after_commit: true)
+        return @synchronous.subscribe(subscriber, to: to) unless after_commit
+
+        super(subscriber, to: to)
+      end
+
+      def listen_to(event, after_commit: true, &block)
+        return @synchronous.listen_to(event, &block) unless after_commit
+
+        super(event, &block)
+      end
+
+      def unsubscribe(subscriber, from:)
+        @synchronous.unsubscribe(subscriber, from: from)
+        super
+      end
 
       def trigger(event)
-        available = defined?(::ActiveRecord) &&
-          ::ActiveRecord.respond_to?(:after_all_transactions_commit)
-        unless available
+        @synchronous.trigger(event)
+
+        unless active_record_available?
           raise LoadError, 'TransactionalEventManager requires ActiveRecord >= 7.2 ' \
                            '(after_all_transactions_commit). Load Rails before using it.'
         end
 
         ::ActiveRecord.after_all_transactions_commit do
-          dispatch_now(event)
+          deferred_dispatch(event)
         end
       end
 
-      private :dispatch_now
+      private :deferred_dispatch
+
+      private
+
+      def active_record_available?
+        defined?(::ActiveRecord) &&
+          ::ActiveRecord.respond_to?(:after_all_transactions_commit)
+      end
     end
   end
 end

--- a/lib/koine/event_manager/rails.rb
+++ b/lib/koine/event_manager/rails.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'koine/event_manager'
+
+module Koine
+  module EventManager
+    # Defers dispatch until the current DB transaction commits (or runs
+    # immediately when none is open). Loads ActiveRecord lazily so the core
+    # stays dependency-free.
+    class TransactionalEventManager < EventManager
+      alias dispatch_now trigger
+
+      def trigger(event)
+        ::ActiveRecord.after_all_transactions_commit do
+          dispatch_now(event)
+        end
+      end
+
+      private :dispatch_now
+    end
+  end
+end

--- a/lib/koine/event_manager/version.rb
+++ b/lib/koine/event_manager/version.rb
@@ -2,6 +2,6 @@
 
 module Koine
   module EventManager
-    VERSION = '3.0.0'
+    VERSION = '3.1.0'
   end
 end

--- a/spec/koine/event_manager/event_manager_spec.rb
+++ b/spec/koine/event_manager/event_manager_spec.rb
@@ -90,4 +90,36 @@ RSpec.describe Koine::EventManager::EventManager do
       'Hello John Doe from HelloSubscriber',
     ])
   end
+
+  describe 'error isolation' do
+    it 'raises by default (backward compatible)' do
+      manager.listen_to(SayHello) { raise 'boom' }
+
+      expect { manager.trigger(SayHello.new([], 'x')) }.to raise_error('boom')
+    end
+
+    it 'isolates a failing listener and keeps the rest running' do
+      errors = []
+      isolated = described_class.new(on_error: ->(error, **) { errors << error })
+      ran = false
+      isolated.listen_to(SayHello) { raise 'boom' }
+      isolated.listen_to(SayHello) { ran = true }
+
+      isolated.trigger(SayHello.new([], 'x'))
+
+      expect(ran).to be true
+      expect(errors.first.message).to eq 'boom'
+    end
+  end
+
+  describe '#publish' do
+    it 'is an alias-style emitter that dispatches through #trigger' do
+      seen = []
+      manager.listen_to(SayHello) { |event| seen << event.name }
+
+      manager.publish(SayHello.new([], 'Joe'))
+
+      expect(seen).to eq ['Joe']
+    end
+  end
 end

--- a/spec/koine/event_manager/rails_spec.rb
+++ b/spec/koine/event_manager/rails_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'koine/event_manager/rails'
+
+RSpec.describe Koine::EventManager::TransactionalEventManager do
+  subject(:manager) { described_class.new }
+
+  let(:deferred) { [] }
+
+  before do
+    captured = deferred
+    fake = Module.new
+    fake.define_singleton_method(:after_all_transactions_commit) do |&block|
+      captured << block
+    end
+    stub_const('ActiveRecord', fake)
+  end
+
+  it 'defers dispatch until the transaction commits' do
+    received = []
+    manager.listen_to(SayHello) { |event| received << event.name }
+
+    manager.trigger(SayHello.new([], 'Joe'))
+    expect(received).to be_empty
+
+    deferred.each(&:call)
+    expect(received).to eq ['Joe']
+  end
+end

--- a/spec/koine/event_manager/rails_spec.rb
+++ b/spec/koine/event_manager/rails_spec.rb
@@ -34,4 +34,65 @@ RSpec.describe Koine::EventManager::TransactionalEventManager do
     expect { manager.trigger(SayHello.new([], 'Joe')) }
       .to raise_error(LoadError, /ActiveRecord/)
   end
+
+  describe 'per-subscriber timing' do
+    let(:recording_subscriber) do
+      Class.new do
+        attr_reader :received
+
+        def initialize
+          @received = []
+        end
+
+        def publish(event)
+          @received << event.name
+        end
+      end.new
+    end
+
+    let(:failing_subscriber) do
+      Class.new do
+        def publish(_event)
+          raise 'boom'
+        end
+      end.new
+    end
+
+    it 'dispatches after_commit: false subscribers synchronously, in-transaction' do
+      manager.subscribe(recording_subscriber, to: SayHello, after_commit: false)
+
+      manager.trigger(SayHello.new([], 'Joe'))
+
+      # Ran inline, without any deferred block having to fire.
+      expect(recording_subscriber.received).to eq ['Joe']
+    end
+
+    it 'defers subscribers by default' do
+      manager.subscribe(recording_subscriber, to: SayHello)
+
+      manager.trigger(SayHello.new([], 'Joe'))
+      expect(recording_subscriber.received).to be_empty
+
+      deferred.each(&:call)
+      expect(recording_subscriber.received).to eq ['Joe']
+    end
+
+    it 'propagates synchronous subscriber errors so they can abort the transaction' do
+      isolated = described_class.new(on_error: ->(*) {})
+      isolated.subscribe(failing_subscriber, to: SayHello, after_commit: false)
+
+      expect { isolated.trigger(SayHello.new([], 'x')) }.to raise_error('boom')
+    end
+
+    it 'isolates deferred subscriber errors via on_error' do
+      errors = []
+      isolated = described_class.new(on_error: ->(error, **) { errors << error })
+      isolated.subscribe(failing_subscriber, to: SayHello)
+
+      isolated.trigger(SayHello.new([], 'x'))
+      deferred.each(&:call)
+
+      expect(errors.first.message).to eq 'boom'
+    end
+  end
 end

--- a/spec/koine/event_manager/rails_spec.rb
+++ b/spec/koine/event_manager/rails_spec.rb
@@ -27,4 +27,11 @@ RSpec.describe Koine::EventManager::TransactionalEventManager do
     deferred.each(&:call)
     expect(received).to eq ['Joe']
   end
+
+  it 'raises a clear error when ActiveRecord is unavailable' do
+    hide_const('ActiveRecord')
+
+    expect { manager.trigger(SayHello.new([], 'Joe')) }
+      .to raise_error(LoadError, /ActiveRecord/)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,8 @@ end
 
 SayHello = Struct.new(:output, :name)
 SayGoodBye = Struct.new(:output, :name)
-SayHelloAgain = Class.new(SayHello)
+class SayHelloAgain < SayHello
+end
 
 class HelloSubscriber
   def publish(event)


### PR DESCRIPTION
## What
- **`on_error` hook** — `EventManager.new(on_error:)` isolates a failing listener/subscriber so it does not abort the rest of the dispatch. Default behavior re-raises (backward compatible).
- **`#publish`** — emitter alias for `#trigger` (pub/sub vocabulary).
- **Optional Rails integration** — `require "koine/event_manager/rails"` adds `TransactionalEventManager`, which defers dispatch via `ActiveRecord.after_all_transactions_commit`. ActiveRecord is referenced only in that file (with a clear `LoadError` guard), so the core stays dependency-free; the spec stubs it.
- **Per-subscriber timing** — listeners are deferred (post-commit) by default; a reaction that must run in-transaction opts out with `after_commit: false`. Synchronous listeners run inline and their errors **propagate** (so they can abort the surrounding transaction), bypassing `on_error`; deferred listeners stay isolated.

Bumps to 3.1.0. Used downstream by credclub (#2105).